### PR TITLE
Jmac/callgraph importer

### DIFF
--- a/import/callgraph-parser.py
+++ b/import/callgraph-parser.py
@@ -126,8 +126,8 @@ def main():
     while True:
         l = indexfile.readline()
         if l == "": break
-        (symbol, location) = l.split(":",1)
-        index[symbol]=location.strip()
+        (symbol, objectName, libraryName) = l.split(":")
+        index[symbol]= "%s:%s"%(libraryName.strip(),objectName.strip())
 
     if len(sys.argv) > 1:
         if os.path.isdir(sys.argv[1]):

--- a/import/callgraph-parser.py
+++ b/import/callgraph-parser.py
@@ -94,8 +94,8 @@ def processPackage(filename, directory):
                 if called not in index:
                     callDest = "NULL:"+demangle(called)
                 else:
-                    location = index[called]
-                    callDest = location+":"+demangle(called)
+                    packageObjectName = index[called]
+                    callDest = packageObjectName+":"+demangle(called)
             symbolYaml['calls'].append("id:"+callDest)
 
     # Empty 'contains' fields cause problems, so delete them

--- a/import/callgraph-parser.py
+++ b/import/callgraph-parser.py
@@ -94,7 +94,6 @@ def processPackage(packageName, directory):
                 else:
                     location = index[called]
                     callDest = location+":"+demangle(called)
-            callYaml = { '@id': "id:"+callDest }
             symbolYaml['calls'].append("id:"+callDest)
 
     # Empty 'contains' fields cause problems, so delete them


### PR DESCRIPTION
This series of patches should fix the reversed package/object name issue which was breaking call links. I've also removed the 'call.' prefix from all IDs and made a few other miscellaneous improvements.
