### PR TITLE
Jmac/better node names

### DIFF
--- a/block-layout/examples/object-view-demo.ts
+++ b/block-layout/examples/object-view-demo.ts
@@ -95,6 +95,39 @@ var symbolArray : D3Symbol[] = [];
 var callGraph : Call[] = [];
 var objectCalls = [];
 
+function countChars(s: string, c:string) : number
+{
+    var n:number =0;
+    for(var i:number=0;i<s.length;i++) {
+	if(s.charAt(i) == c) n++;
+    }
+    return n;
+}
+
+function abbreviateSymbol(s: string) : string
+{
+    var x : number = s.lastIndexOf("::")
+    if(x>=0) s = s.substring(x+2);
+
+    if(s.toUpperCase() != s && s.toLowerCase() != s) {
+	// This looks like mixed case, maybe camelcase
+	var initials : string = "";
+	for(var i:number=0;i<s.length;i++) {
+	    if(s[i].toUpperCase() == s[i]) initials += s[i];
+	}
+	s = initials;
+    }
+    else if(countChars(s, '_') > 2 && s.length>5) {
+	// Looks like an underscore-separated name
+	var initials : string = "";
+	for(var i:number=1;i<s.length;i++) {
+	    if(s[i] == '_' && s[i-1] != '_') initials += s[i-1];
+	}
+	s = initials;
+    }
+    return s;
+}
+
 function database()
 {
     // This function fetches JSON from the graph database intermediate server (server.py)
@@ -123,7 +156,7 @@ function database()
 		    if(node.parent != object._id) {
 			console.log("Symbol "+node._id+ " is in the wrong parent and will not be recorded (symbol parent "+node.parent+", object id "+object._id);
 		    } else {
-			symbolArray.push( new D3Symbol(node.caption.substr(0,4), object.caption.substr(0,4), node._id) );
+			symbolArray.push( new D3Symbol(abbreviateSymbol(node.caption), object.caption, node._id) );
 			console.log("Recording map of symbol "+node._id+" to object "+object._id)
 			if(nodeToObjectMap[node._id]) {
 			    console.log("Warning: symbol "+node._id+" was already mapped to "+nodeToObjectMap[node._id]._id);

--- a/block-layout/examples/object-view-demo.ts
+++ b/block-layout/examples/object-view-demo.ts
@@ -1,18 +1,18 @@
 var exampleJSON = [
-    { "Object": "Sym1", "parent": "d3d.o", "sortIndex": 0, "_id": 0 },
-    { "Object": "Sym2", "parent": "d3d.o", "sortIndex": 1, "_id": 1 },
-    { "Object": "Sym3", "parent": "d3d.o", "sortIndex": 2, "_id": 2 },
-    { "Object": "Sym4", "parent": "d3d.o", "sortIndex": 2, "_id": 3 },
-    { "Object": "Sym1", "parent": "ttf.o", "sortIndex": 0, "_id": 4 },
-    { "Object": "Sym2", "parent": "ttf.o", "sortIndex": 0, "_id": 5 },
-    { "Object": "Sym3", "parent": "ttf.o", "sortIndex": 0, "_id": 6 },
-    { "Object": "Sym1", "parent": "alx.o", "sortIndex": 0, "_id": 7 },
-    { "Object": "Sym2", "parent": "alx.o", "sortIndex": 1, "_id": 8 },
-    { "Object": "Sym3", "parent": "alx.o", "sortIndex": 2, "_id": 9 },
-    { "Object": "Sym1", "parent": "klf.o", "sortIndex": 0, "_id": 10 },
-    { "Object": "Sym2", "parent": "klf.o", "sortIndex": 1, "_id": 11 },
-    { "Object": "Sym3", "parent": "klf.o", "sortIndex": 2, "_id": 12 },
-    { "Object": "Sym4", "parent": "klf.o", "sortIndex": 2, "_id": 13 },
+    { "symbolName": "Sym1", "parent": "d3d.o", "sortIndex": 0, "_id": 0 },
+    { "symbolName": "Sym2", "parent": "d3d.o", "sortIndex": 1, "_id": 1 },
+    { "symbolName": "Sym3", "parent": "d3d.o", "sortIndex": 2, "_id": 2 },
+    { "symbolName": "Sym4", "parent": "d3d.o", "sortIndex": 2, "_id": 3 },
+    { "symbolName": "Sym1", "parent": "ttf.o", "sortIndex": 0, "_id": 4 },
+    { "symbolName": "Sym2", "parent": "ttf.o", "sortIndex": 0, "_id": 5 },
+    { "symbolName": "Sym3", "parent": "ttf.o", "sortIndex": 0, "_id": 6 },
+    { "symbolName": "Sym1", "parent": "alx.o", "sortIndex": 0, "_id": 7 },
+    { "symbolName": "Sym2", "parent": "alx.o", "sortIndex": 1, "_id": 8 },
+    { "symbolName": "Sym3", "parent": "alx.o", "sortIndex": 2, "_id": 9 },
+    { "symbolName": "Sym1", "parent": "klf.o", "sortIndex": 0, "_id": 10 },
+    { "symbolName": "Sym2", "parent": "klf.o", "sortIndex": 1, "_id": 11 },
+    { "symbolName": "Sym3", "parent": "klf.o", "sortIndex": 2, "_id": 12 },
+    { "symbolName": "Sym4", "parent": "klf.o", "sortIndex": 2, "_id": 13 },
 ];
 
 class Call {
@@ -26,6 +26,7 @@ class Call {
 interface D3Symbol {
     highlight?: number; // Default 0; -ve values indicate a caller and +ve a callee
     sortIndex?: number;
+    shortName?: string;
 }
 
 // Symbols which D3 expects in an array.
@@ -33,11 +34,11 @@ class D3Symbol {
     constructor(symbolName: string, parentName: string, index: number) {
 	this.highlight = 0;
 	this._id = index;
-	this.Object = symbolName;
+	this.symbolName = symbolName;
 	this.parent = parentName;
 	this.sortIndex = 0;
     }
-    Object: string;
+    symbolName: string;
     parent: string;
     _id: number;
 }
@@ -156,7 +157,7 @@ function database()
 		    if(node.parent != object._id) {
 			console.log("Symbol "+node._id+ " is in the wrong parent and will not be recorded (symbol parent "+node.parent+", object id "+object._id);
 		    } else {
-			symbolArray.push( new D3Symbol(abbreviateSymbol(node.caption), object.caption, node._id) );
+			symbolArray.push( { "symbolName": node.caption, "shortName": abbreviateSymbol(node.caption), "parent": object.caption, "sortIndex": 0, "_id": node._id});
 			console.log("Recording map of symbol "+node._id+" to object "+object._id)
 			if(nodeToObjectMap[node._id]) {
 			    console.log("Warning: symbol "+node._id+" was already mapped to "+nodeToObjectMap[node._id]._id);
@@ -279,7 +280,7 @@ function nodeDrawCallback(_this, thing)
             _this.tip.hide();
             _this.config.onClick(obj);
         });
-    group.append('text').attr('x', 0).attr('y', (_this.config.blockSize)/2).attr("fill", "#000").text(function(obj) { return obj.Object; });
+    group.append('text').attr('x', 0).attr('y', (_this.config.blockSize)/2).attr("fill", "#000").text(function(obj) { return obj.shortName || obj.symbolName; });
     group.attr('class', 'relationshipGraph-node');
 
 

--- a/block-layout/src/index.ts
+++ b/block-layout/src/index.ts
@@ -150,7 +150,7 @@ var define, exports, require, module;
          * @returns {d3.tip} the tip object.
          */
         var createTooltip = function(self) {
-            var hiddenKeys = ['ROW', 'INDEX', 'COLOR', 'PARENTCOLOR', 'PARENT'],
+            var shownKeys = ['SYMBOLNAME'],
                 showKeys = self.config.showKeys;
 
             return d3.tip().attr('class', 'relationshipGraph-tip')
@@ -166,7 +166,7 @@ var define, exports, require, module;
                         var element = keys[count],
                             upperCaseKey = element.toUpperCase();
 
-                        if (!contains(hiddenKeys, upperCaseKey)) {
+                        if (contains(shownKeys, upperCaseKey)) {
                             var row = document.createElement('tr'),
                                 key = showKeys ? document.createElement('td') : null,
                                 value = document.createElement('td');

--- a/block-layout/src/index.ts
+++ b/block-layout/src/index.ts
@@ -571,27 +571,33 @@ var define, exports, require, module;
 		return y;
 	    }
 
+	    function parentTextYFunction(obj, index) {
+		var y : number = parentBoxYFunction(obj,index) + parentBoxHeightFunction(obj,index)/2 + parentTextFunction(obj,index).length*2;
+		return y;
+	    }
+
 	    function parentBoxHeightFunction(obj, index) {
                 var children = Math.ceil(parentSizes[obj] / calculatedMaxChildren) * calculatedMaxChildren;
                 return 8 + Math.ceil(children / calculatedMaxChildren) * _this.config.blockSize;
 	    }
+
 	    function parentTextFunction(obj, index) {
                 return obj + ' (' + parentSizes[obj] + ')';
 	    }
+
 	    // Add new parent nodes.
             var parentGroups = [];
             for (i = 0; i < parentNodes.length; i++) {
                 parentGroups[i] = parentNodes[i].enter().append('g');
                 parentGroups[i].append('text')
                     .text(parentTextFunction)
-                    .attr('x', 8)
-                    .attr('y', parentBoxYFunction)
+                    .attr('x', 0)
+                    .attr('y', parentTextYFunction)
                     .style('text-anchor', 'start')
                     .style('fill', function(obj) {
                        return (obj.parentColor !== undefined) ? _this.config.colors[obj.parentColor] : '#000000';
                     })
                     .attr('class', 'relationshipGraph-Text')
-                    .attr('transform', 'translate(-6, ' + this.config.blockSize / 1.5 + ')');
             }
 
 	    // Add a rectangle which should enclose all objects
@@ -612,11 +618,12 @@ var define, exports, require, module;
                 previousParents = []; // helper to calculate parentBoxY
                 parentNodes[i].select('text')
                     .text(parentTextFunction)
-                    .attr('x', 8)
-                    .attr('y', parentBoxYFunction)
+                    .attr('x', 0)
+                    .attr('y', 0)
                     .style('fill', function(obj) {
                         return (obj.parentColor !== undefined) ? _this.config.colors[obj.parentColor] : '#000000';
-                    });
+                    })
+		    .attr("transform", function(obj, index) { return "translate(16,"+parentTextYFunction(obj,index)+") rotate (-90)"; });
             }
 
             // Remove deleted parent nodes.
@@ -707,7 +714,7 @@ var define, exports, require, module;
             // Update existing child nodes.
             for (i = 0; i < childrenNodes.length; i++) {
                 childrenNodes[i].transition(_this.config.transitionTime)
-                    .attr( "transform", function(obj) { var x = longestWidth + ((obj.index - 1) * _this.config.blockSize);
+                    .attr( "transform", function(obj) { var x = 32 + ((obj.index - 1) * _this.config.blockSize);
                                                         var y = nodeYFunction(obj);
                                                         return "translate ("+x+" "+y+")"; })
                     .style('fill', function(obj) {

--- a/block-layout/src/index.ts
+++ b/block-layout/src/index.ts
@@ -677,28 +677,35 @@ var define, exports, require, module;
 			var x2 : number = linkXFunction(target);
 			var y1 : number = linkYFunction(source);
 			var y2 : number = linkYFunction(target);
+
+			var lineXOffset : number = 32;
+			var lineYOffset : number = 48;
+
 			var path: string = "";
+			// Start marker
+			path += " M"+(x1 + lineXOffset) + ","+(y1+lineYOffset);
+			path += " L"+(x1 + lineXOffset - 4) + ","+(y1+lineYOffset - 4);
+			path += " L"+(x1 + lineXOffset - 4) + ","+(y1+lineYOffset + 4);
+			path += " L"+(x1 + lineXOffset) + ","+(y1+lineYOffset);
 			if (y1 == y2) {
 			    if (x1 == x2) {
 				// This calls itself; ignore it
 			    } else {
-				path = "M "+(x1 + 64) + ","+(y1+32);
-				path += " C "+(x1 + 64) + ","+(y1+128);
-				path += " "+(x2 + 64) + ","+(y2+128);
-				path += " "+(x2 + 64) + ","+(y2+32);
-				path += " L"+(x2 + 64 - 4) + ","+(y2+32 - 4);
-				path += " L"+(x2 + 64 - 4) + ","+(y2+32 + 4);
-				path += " L"+(x2 + 64) + ","+(y2+32);
+				path += " C "+(x1 + lineXOffset) + ","+(y1+128);
+				path += " "+(x2 + lineXOffset) + ","+(y2+128);
+				path += " "+(x2 + lineXOffset) + ","+(y2+lineYOffset);
 			    }
 			} else {
-			    path = "M "+(x1 + 64) + ","+(y1+32);
-			    path += " C "+(x1 + 64+256) + ","+(y1+32);
-			    path += " "+(x2 + 64+256) + ","+(y2+32);
-			    path += " "+(x2 + 64) + ","+(y2+32);
-			    path += " L"+(x2 + 64 - 4) + ","+(y2+32 - 4);
-			    path += " L"+(x2 + 64 - 4) + ","+(y2+32 + 4);
-			    path += " L"+(x2 + 64) + ","+(y2+32);
+			    path += " C "+(x1 + lineXOffset+256) + ","+(y1+lineYOffset);
+			    path += " "+(x2 + lineXOffset+256) + ","+(y2+lineYOffset);
+			    path += " "+(x2 + lineXOffset) + ","+(y2+lineYOffset);
 			}
+			// End marker
+			path += " M"+(x2 + lineXOffset - 4) + ","+(y2+lineYOffset - 4);
+			path += " L"+(x2 + lineXOffset - 4) + ","+(y2+lineYOffset + 4);
+			path += " L"+(x2 + lineXOffset + 4) + ","+(y2+lineYOffset + 4);
+			path += " L"+(x2 + lineXOffset + 4) + ","+(y2+lineYOffset - 4);
+			path += " L"+(x2 + lineXOffset - 4) + ","+(y2+lineYOffset - 4);
 			return path;
 		    });
 	    }


### PR DESCRIPTION
This is the first attempt at shortening symbol names so something fits on the node square. You can see the full node name by hovering over the node. I've also altered the object name so it shows as vertical text and altered the node layout slightly. There's some better start/end markers for the call lines.
