### PR TITLE
Fix makefile bug

### DIFF
--- a/block-layout/Makefile
+++ b/block-layout/Makefile
@@ -1,6 +1,5 @@
 all: check-tsc
 	cd examples; make
-	cd src; make
 
 check-tsc:
 	@which tsc || (echo "You need the TypeScript compiler (tsc) on your path."; /bin/false; )

--- a/block-layout/Makefile
+++ b/block-layout/Makefile
@@ -1,5 +1,5 @@
 all: check-tsc
-	cd examples; make
+	cd examples && $(MAKE)
 
 check-tsc:
 	@which tsc || (echo "You need the TypeScript compiler (tsc) on your path."; /bin/false; )

--- a/block-layout/examples/object-view-demo.ts
+++ b/block-layout/examples/object-view-demo.ts
@@ -1,3 +1,4 @@
+/// <reference path="../src/index.ts" />
 /// <reference path="exampleData.ts" />
 /// <reference path="nodePositioning.ts" />
 /// <reference path="loadingAnimation.ts" />

--- a/block-layout/examples/showpackage.html
+++ b/block-layout/examples/showpackage.html
@@ -6,7 +6,6 @@
 
     <script src="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
     <script src="../src/d3-tip.js"></script>
-    <script src="../src/index.js"></script>
     <script type="text/javascript" src="resources/jquery/dist/jquery.min.js"></script>
     <link type="text/css" rel="stylesheet" href="../dest/d3.relationshipgraph.min.css">
     <link type="text/css" rel="stylesheet" href="index.css">

--- a/block-layout/src/Makefile
+++ b/block-layout/src/Makefile
@@ -1,3 +1,0 @@
-all:	index.ts
-	tsc index.ts || /bin/true
-


### PR DESCRIPTION
Second attempt at this - we don't need to build 'index.ts' at all; it can be included in the target program using a reference in typescript. 
