### PR TITLE
Change the default web server to cherrypy.

### DIFF
--- a/block-layout/server.py
+++ b/block-layout/server.py
@@ -523,4 +523,5 @@ def annotated_package_list():
 #node_number = graph_node_number("id:package/source/libgtk")
 #print(graph_present(node_number))
 
-app.run(port=args.port)
+# Add "host='0.0.0.0'" to the list of options here to serve on all interfaces
+app.run(port=args.port, server='cherrypy')


### PR DESCRIPTION
Very small change, just changes the default single-threaded http implementation to a multi-threaded one, as we've had in use on the public demo.
